### PR TITLE
Generate random amounts of $0.01+

### DIFF
--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func randomAmount() *Decimal {
-	return NewDecimal(rand.Int63n(10000), 2)
+	return NewDecimal(1+rand.Int63n(9999), 2)
 }
 
 func TestTransactionCreateSubmitForSettlementAndVoid(t *testing.T) {


### PR DESCRIPTION
What
===
Change the test helper random amount function so that it generates
random amounts that are above zero.

Why
===
@jvalecillos saw a couple CI builds fail when `randomAmount` generated a
zero amount. The places where the helper function is used assume a
non-zero amount.

Fixes #266