### PR TITLE
Add more tests around client token marshalling

### DIFF
--- a/client_token_integration_test.go
+++ b/client_token_integration_test.go
@@ -5,6 +5,8 @@ package braintree
 import (
 	"context"
 	"testing"
+
+	"github.com/braintree-go/braintree-go/testhelpers"
 )
 
 // This test will fail unless you set up your Braintree sandbox account correctly. See TESTING.md for details.
@@ -53,8 +55,6 @@ func TestClientTokenGateway_GenerateWithRequest(t *testing.T) {
 		t.Error(err)
 	}
 
-	trueValue := true
-
 	tests := []struct {
 		name    string
 		req     *ClientTokenRequest
@@ -86,14 +86,37 @@ func TestClientTokenGateway_GenerateWithRequest(t *testing.T) {
 			req:  &ClientTokenRequest{CustomerID: customer.Id, MerchantAccountID: testMerchantAccountId},
 		},
 		{
-			name: "request with customer id and merchant id and options",
+			name: "request with customer id and merchant id and options verify card not set",
 			req: &ClientTokenRequest{
 				CustomerID:        customer.Id,
 				MerchantAccountID: testMerchantAccountId,
 				Options: &ClientTokenRequestOptions{
 					FailOnDuplicatePaymentMethod: true,
 					MakeDefault:                  true,
-					VerifyCard:                   &trueValue,
+				},
+			},
+		},
+		{
+			name: "request with customer id and merchant id and options verify card true",
+			req: &ClientTokenRequest{
+				CustomerID:        customer.Id,
+				MerchantAccountID: testMerchantAccountId,
+				Options: &ClientTokenRequestOptions{
+					FailOnDuplicatePaymentMethod: true,
+					MakeDefault:                  true,
+					VerifyCard:                   testhelpers.BoolPtr(true),
+				},
+			},
+		},
+		{
+			name: "request with customer id and merchant id and options verify card false",
+			req: &ClientTokenRequest{
+				CustomerID:        customer.Id,
+				MerchantAccountID: testMerchantAccountId,
+				Options: &ClientTokenRequestOptions{
+					FailOnDuplicatePaymentMethod: true,
+					MakeDefault:                  true,
+					VerifyCard:                   testhelpers.BoolPtr(false),
 				},
 			},
 		},

--- a/client_token_test.go
+++ b/client_token_test.go
@@ -1,0 +1,116 @@
+// +build unit
+
+package braintree
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/braintree-go/braintree-go/testhelpers"
+)
+
+func TestClientToken_MarshalXML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		req     *ClientTokenRequest
+		wantXML string
+	}{
+		{
+			name: "request empty",
+			req:  &ClientTokenRequest{},
+			wantXML: `<client-token>
+  <version>0</version>
+</client-token>`,
+		},
+		{
+			name: "request with provided version",
+			req:  &ClientTokenRequest{Version: 2},
+			wantXML: `<client-token>
+  <version>2</version>
+</client-token>`,
+		},
+		{
+			name: "request with customer and merchant account",
+			req: &ClientTokenRequest{
+				CustomerID:        "1234",
+				MerchantAccountID: "5678",
+			},
+			wantXML: `<client-token>
+  <customer-id>1234</customer-id>
+  <merchant-account-id>5678</merchant-account-id>
+  <version>0</version>
+</client-token>`,
+		},
+		{
+			name: "request with non-pointer options false",
+			req: &ClientTokenRequest{
+				Options: &ClientTokenRequestOptions{
+					FailOnDuplicatePaymentMethod: false,
+					MakeDefault:                  false,
+				},
+			},
+			wantXML: `<client-token>
+  <options></options>
+  <version>0</version>
+</client-token>`,
+		},
+		{
+			name: "request with non-pointer options true",
+			req: &ClientTokenRequest{
+				Options: &ClientTokenRequestOptions{
+					FailOnDuplicatePaymentMethod: true,
+					MakeDefault:                  true,
+				},
+			},
+			wantXML: `<client-token>
+  <options>
+    <fail-on-duplicate-payment-method>true</fail-on-duplicate-payment-method>
+    <make-default>true</make-default>
+  </options>
+  <version>0</version>
+</client-token>`,
+		},
+		{
+			name: "request with verify card true",
+			req: &ClientTokenRequest{
+				Options: &ClientTokenRequestOptions{
+					VerifyCard: testhelpers.BoolPtr(true),
+				},
+			},
+			wantXML: `<client-token>
+  <options>
+    <verify-card>true</verify-card>
+  </options>
+  <version>0</version>
+</client-token>`,
+		},
+		{
+			name: "request with verify card false",
+			req: &ClientTokenRequest{
+				Options: &ClientTokenRequestOptions{
+					VerifyCard: testhelpers.BoolPtr(false),
+				},
+			},
+			wantXML: `<client-token>
+  <options>
+    <verify-card>false</verify-card>
+  </options>
+  <version>0</version>
+</client-token>`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := xml.MarshalIndent(test.req, "", "  ")
+			xml := string(output)
+			if err != nil {
+				t.Fatalf("got error = %v", err)
+			}
+			if xml != test.wantXML {
+				t.Errorf("got xml:\n%s\nwant xml:\n%s", xml, test.wantXML)
+			}
+		})
+	}
+}

--- a/client_token_test.go
+++ b/client_token_test.go
@@ -18,6 +18,11 @@ func TestClientToken_MarshalXML(t *testing.T) {
 		wantXML string
 	}{
 		{
+			name:    "request nil",
+			req:     nil,
+			wantXML: ``,
+		},
+		{
 			name: "request empty",
 			req:  &ClientTokenRequest{},
 			wantXML: `<client-token>


### PR DESCRIPTION
What
===
Add more tests around client token marshalling that exercise all the
fields being serialized.

Why
===
I suspect the VerifyCard *bool field is an issue on older versions of Go
still officially supported, and that is being fixed in #268, but I'd like to
see it broken on master.

FYI
===
@jvalecillos 