### PR TITLE
Add ProcessorResponseType to Transaction

### DIFF
--- a/processor_response_type.go
+++ b/processor_response_type.go
@@ -1,0 +1,9 @@
+package braintree
+
+type ProcessorResponseType string
+
+const (
+	ProcessorResponseTypeApproved     ProcessorResponseType = "approved"
+	ProcessorResponseTypeSoftDeclined ProcessorResponseType = "soft_declined"
+	ProcessorResponseTypeHardDeclined ProcessorResponseType = "hard_declined"
+)

--- a/transaction.go
+++ b/transaction.go
@@ -77,6 +77,7 @@ type Transaction struct {
 	RefundedTransactionId        *string                   `xml:"refunded-transaction-id"`
 	ProcessorResponseCode        ProcessorResponseCode     `xml:"processor-response-code"`
 	ProcessorResponseText        string                    `xml:"processor-response-text"`
+	ProcessorResponseType        ProcessorResponseType     `xml:"processor-response-type"`
 	ProcessorAuthorizationCode   string                    `xml:"processor-authorization-code"`
 	SettlementBatchId            string                    `xml:"settlement-batch-id"`
 	EscrowStatus                 EscrowStatus              `xml:"escrow-status"`

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -428,6 +428,9 @@ func TestTransactionCreateWhenGatewayRejected(t *testing.T) {
 	if err.(*BraintreeError).Transaction.ProcessorResponseCode != 2010 {
 		t.Fatalf("expected err.Transaction.ProcessorResponseCode to be 2010, but got %d", err.(*BraintreeError).Transaction.ProcessorResponseCode)
 	}
+	if err.(*BraintreeError).Transaction.ProcessorResponseType != ProcessorResponseTypeHardDeclined {
+		t.Fatalf("expected err.Transaction.ProcessorResponseType to be %s, but got %s", ProcessorResponseTypeHardDeclined, err.(*BraintreeError).Transaction.ProcessorResponseType)
+	}
 
 	if err.(*BraintreeError).Transaction.AdditionalProcessorResponse != "2010 : Card Issuer Declined CVV" {
 		t.Fatalf("expected err.Transaction.ProcessorResponseCode to be `2010 : Card Issuer Declined CVV`, but got %s", err.(*BraintreeError).Transaction.AdditionalProcessorResponse)
@@ -965,6 +968,10 @@ func TestAllTransactionFields(t *testing.T) {
 	if tx2.AdditionalProcessorResponse != "" {
 		t.Fatalf("expected tx2.AdditionalProcessorResponse to be empty, but got %s", tx2.AdditionalProcessorResponse)
 	}
+	if tx2.ProcessorResponseType != ProcessorResponseTypeApproved {
+		t.Fatalf("expected tx2.ProcessorResponseType to be %s, but got %s", ProcessorResponseTypeApproved, tx2.ProcessorResponseType)
+	}
+
 	if tx2.RiskData == nil {
 		t.Fatal("expected tx2.RiskData not to be empty")
 	}


### PR DESCRIPTION
What
===
Add `ProcessorResponseType` to `Transaction`.

Why
===
The official SDKs now expose a processor response type field on transactions that indicates if a processor response is `approved`, `soft_declined` or `hard_declined`.

https://developers.braintreepayments.com/reference/response/transaction#processor_response_type

FYI @lvidaic

Fixes #227 