### PR TITLE
Feature: add new ProductId field to CreditCard type

### DIFF
--- a/credit_card.go
+++ b/credit_card.go
@@ -39,7 +39,7 @@ type CreditCard struct {
 	UniqueNumberIdentifier    string             `xml:"unique-number-identifier,omitempty"`
 	BillingAddress            *Address           `xml:"billing-address,omitempty"`
 	Subscriptions             *Subscriptions     `xml:"subscriptions,omitempty"`
-	ProductId                 string             `xml:"product_id,omitempty"`
+	ProductID                 string             `xml:"product_id,omitempty"`
 }
 
 type CreditCards struct {

--- a/credit_card.go
+++ b/credit_card.go
@@ -39,7 +39,7 @@ type CreditCard struct {
 	UniqueNumberIdentifier    string             `xml:"unique-number-identifier,omitempty"`
 	BillingAddress            *Address           `xml:"billing-address,omitempty"`
 	Subscriptions             *Subscriptions     `xml:"subscriptions,omitempty"`
-	ProductID                 string             `xml:"product_id,omitempty"`
+	ProductID                 string             `xml:"product-id,omitempty"`
 }
 
 type CreditCards struct {

--- a/credit_card.go
+++ b/credit_card.go
@@ -39,6 +39,7 @@ type CreditCard struct {
 	UniqueNumberIdentifier    string             `xml:"unique-number-identifier,omitempty"`
 	BillingAddress            *Address           `xml:"billing-address,omitempty"`
 	Subscriptions             *Subscriptions     `xml:"subscriptions,omitempty"`
+	ProductId                 string             `xml:"product_id,omitempty"`
 }
 
 type CreditCards struct {

--- a/credit_card_integration_test.go
+++ b/credit_card_integration_test.go
@@ -42,6 +42,9 @@ func TestCreditCard(t *testing.T) {
 	if card.Token == "" {
 		t.Fatal("invalid token")
 	}
+	if card.ProductID != "Unknown" { // Unknown appears to be reported from the Braintree Sandbox environment for all cards.
+		t.Errorf("got product id %q, want %q", card.ProductID, "Unknown")
+	}
 
 	// Update
 	card2, err := g.Update(ctx, &CreditCard{


### PR DESCRIPTION
See #272 for context.

Adds new field `ProductId` to the `CreditCard` model.

Couldn't see any tests that maybe  affect this, let me know if I need to add any :+1: 