### PR TITLE
Add `AuthorizationExpiresAt` to `Transaction`

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -98,6 +98,7 @@ type Transaction struct {
 	GatewayRejectionReason       GatewayRejectionReason    `xml:"gateway-rejection-reason"`
 	PurchaseOrderNumber          string                    `xml:"purchase-order-number"`
 	Disputes                     []*Dispute                `xml:"disputes>dispute"`
+	AuthorizationExpiresAt       *time.Time                `xml:"authorization-expires-at"`
 }
 
 type TransactionRequest struct {

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -990,6 +990,9 @@ func TestAllTransactionFields(t *testing.T) {
 	if tx2.SubscriptionDetails != nil {
 		t.Fatalf("expected Subscription to be not nil, but got %#v", tx2.SubscriptionDetails)
 	}
+	if tx2.AuthorizationExpiresAt == nil {
+		t.Fatalf("expected AuthorizationExpiresAt to be not nil, but got %#v", tx2.AuthorizationExpiresAt)
+	}
 }
 
 // This test will only pass on Travis. See TESTING.md for more details.

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -992,6 +992,8 @@ func TestAllTransactionFields(t *testing.T) {
 	}
 	if tx2.AuthorizationExpiresAt == nil {
 		t.Fatalf("expected AuthorizationExpiresAt to be not nil, but got %#v", tx2.AuthorizationExpiresAt)
+	} else if tx2.AuthorizationExpiresAt.Before(time.Now()) || tx2.AuthorizationExpiresAt.After(time.Now().AddDate(0, 0, 60)) {
+		t.Fatalf("expected AuthorizationExpiresAt to be between the current time and 60 days from now, but got %s", tx2.AuthorizationExpiresAt.Format(time.RFC3339))
 	}
 }
 


### PR DESCRIPTION
What
----
Add `AuthorizationExpiresAt` to `Transaction`

Why
---
This field is now supported by the other SDKs, providing a datetime that
the authorization will expire (if it is still in authorized state)o

https://developers.braintreepayments.com/reference/response/transaction/ruby#authorization_expires_at