### PR TITLE
Add a RefundWithRequest method to TransactionGateway

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -130,6 +130,12 @@ type TransactionRequest struct {
 	LineItems           TransactionLineItemRequests `xml:"line-items,omitempty"`
 }
 
+type TransactionRefundRequest struct {
+	XMLName string   `xml:"transaction"`
+	Amount  *Decimal `xml:"amount"`
+	OrderID string   `xml:"order-id,omitempty"`
+}
+
 func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	type typeWithNoFunctions Transaction
 	if err := d.DecodeElement((*typeWithNoFunctions)(t), &start); err != nil {

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -140,6 +140,22 @@ func (g *TransactionGateway) Refund(ctx context.Context, id string, amount ...*D
 	return nil, &invalidResponseError{resp}
 }
 
+// RefundWithRequest is similar to Refund, but allows more parameters such as
+// OrderID to be included as part of the refund request.
+func (g *TransactionGateway) RefundWithRequest(ctx context.Context, id string, refundRequest *TransactionRefundRequest) (*Transaction, error) {
+	resp, err := g.execute(ctx, "POST", "transactions/"+id+"/refund", refundRequest)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return resp.transaction()
+	case 201:
+		return resp.transaction()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
 // Find finds the transaction with the specified id.
 func (g *TransactionGateway) Find(ctx context.Context, id string) (*Transaction, error) {
 	resp, err := g.execute(ctx, "GET", "transactions/"+id, nil)


### PR DESCRIPTION
The current `Refund` method cannot take additional parameters like
`OrderId`. This new method allows those parameters to be passed as part of
a request structure.

Fixes #276