### PR TITLE
Serialize decimals to string consistently

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -28,8 +28,8 @@ func (d *Decimal) MarshalText() (text []byte, err error) {
 		b.WriteString(strings.Repeat("0", -d.Scale))
 	} else {
 		str := strconv.FormatInt(d.Unscaled, 10)
-		if len(str) < d.Scale {
-			str = strings.Repeat("0", d.Scale) + str
+		if len(str) <= d.Scale {
+			str = strings.Repeat("0", (d.Scale+1)-len(str)) + str
 		}
 		b.WriteString(str[:len(str)-d.Scale])
 		b.WriteString(".")

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -54,11 +54,24 @@ func TestDecimalMarshalText(t *testing.T) {
 	}{
 		{NewDecimal(250, -2), []byte("25000")},
 		{NewDecimal(2, 0), []byte("2")},
+		{NewDecimal(23, 0), []byte("23")},
+		{NewDecimal(234, 0), []byte("234")},
+		{NewDecimal(0, 1), []byte("0.0")},
+		{NewDecimal(1, 1), []byte("0.1")},
+		{NewDecimal(12, 1), []byte("1.2")},
 		{NewDecimal(0, 2), []byte("0.00")},
 		{NewDecimal(5, 2), []byte("0.05")},
+		{NewDecimal(55, 2), []byte("0.55")},
 		{NewDecimal(250, 2), []byte("2.50")},
 		{NewDecimal(4586, 2), []byte("45.86")},
 		{NewDecimal(-5504, 2), []byte("-55.04")},
+		{NewDecimal(0, 3), []byte("0.000")},
+		{NewDecimal(5, 3), []byte("0.005")},
+		{NewDecimal(55, 3), []byte("0.055")},
+		{NewDecimal(250, 3), []byte("0.250")},
+		{NewDecimal(4586, 3), []byte("4.586")},
+		{NewDecimal(45867, 3), []byte("45.867")},
+		{NewDecimal(-55043, 3), []byte("-55.043")},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
What
===
Change the number of zeros added to the beginning of a decimal that will
only render non-zero digits below a decimal point so that there is
always one zero before the decimal point.

Why
===
The decimal serialization to a string appears to have a couple of
oddities.

`NewDecimal(55, 2)` serialized to `".55"`.
`NewDecimal(55, 3)` serialized to `"00.055"`.

When calculating the number of zeros to add to the beginning of a number
if the scale is larger than the number, it wasn't taking into account if
the length was equal to the scale (e.g. 0.55 where there are two digits
provided and a scale of 2), and the other situation above. The number of
zeros being added was the scale and not the number of zeros missing to
consistently generate a string leading with `0.`.

This shouldn't have caused any issues because the resulting string is still
a valid decimal according to many decimal parsers, but as pointed out by
@midoNuminix in #278 some fields appear to not like the values.