### PR TITLE
Add Go 1.12 to builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 jobs:
   include:
     - stage: analysis
-      go: "1.11.2"
+      go: "1.12.x"
       script: make analysis
 
     - stage: test
@@ -21,9 +21,13 @@ jobs:
       script: make test
 
     - stage: test
-      go: "1.11.2"
+      go: "1.12.x"
       env:
         - GO111MODULE=on
+      script: make test
+
+    - stage: test
+      go: "1.12.x"
       script: make test
 
     - stage: test

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The usual. `go get github.com/braintree-go/braintree-go`
 * 1.9
 * 1.10
 * 1.11
+* 1.12
 
 ### Documentation
 


### PR DESCRIPTION
What
===
Add Go 1.12 to builds.

Why
===
It's been released.

Also
===
Adjust other recent builds to always pick the latest release of that
major release.