### PR TITLE
Fix fully refunded tests

### DIFF
--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -1159,7 +1159,7 @@ func TestTransactionCreateSettleAndFullRefund(t *testing.T) {
 	refundTxn, err = testGateway.Transaction().Refund(ctx, txn.Id)
 	t.Log(refundTxn)
 
-	if err.Error() != "Transaction has already been completely refunded." {
+	if err.Error() != "Transaction has already been fully refunded." {
 		t.Fatal(err)
 	}
 }
@@ -1243,7 +1243,7 @@ func TestTransactionCreateSettleAndFullRefundWithRequest(t *testing.T) {
 	})
 	t.Log(refundTxn)
 
-	if err.Error() != "Transaction has already been completely refunded." {
+	if err.Error() != "Transaction has already been fully refunded." {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
What
===
Update expected error text in tests that check the behavior of
transactions that have been fully refunded.

Why
===
Seems the error text coming back has changed slightly.